### PR TITLE
Remove circular import NotificationDto

### DIFF
--- a/src/ProjectManagerSdk/models/notificationdto.py
+++ b/src/ProjectManagerSdk/models/notificationdto.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 from ProjectManagerSdk.models.notificationdatadto import NotificationDataDto
-from ProjectManagerSdk.models.notificationdto import NotificationDto
 from typing import List
 import dataclasses
 


### PR DESCRIPTION
Fix circular dependency on ResourceDTO.
Mentioned in issue https://github.com/projectmgr/projectmanager-sdk-python/issues/21